### PR TITLE
Bump semver from 5.7.2 to 7.5.4 in /front-end

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -357,7 +357,7 @@
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
       "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
       "dependencies": {
-        "semver": "^7.0.0"
+        "semver": "^7.5.4"
       }
     },
     "node_modules/builtins/node_modules/semver": {
@@ -986,7 +986,7 @@
         "minimatch": "^3.1.2",
         "object.values": "^1.1.6",
         "resolve": "^1.22.1",
-        "semver": "^6.3.0",
+        "semver": "^7.5.4",
         "tsconfig-paths": "^3.14.1"
       },
       "engines": {
@@ -1032,7 +1032,7 @@
         "is-core-module": "^2.11.0",
         "minimatch": "^3.1.2",
         "resolve": "^1.22.1",
-        "semver": "^7.3.8"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=12.22.0"
@@ -1087,7 +1087,7 @@
         "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.4",
-        "semver": "^6.3.0",
+        "semver": "^7.5.4",
         "string.prototype.matchall": "^4.0.8"
       },
       "engines": {
@@ -3753,7 +3753,7 @@
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
       "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
       "requires": {
-        "semver": "^7.0.0"
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "semver": {
@@ -4224,7 +4224,7 @@
         "minimatch": "^3.1.2",
         "object.values": "^1.1.6",
         "resolve": "^1.22.1",
-        "semver": "^6.3.0",
+        "semver": "^7.5.4",
         "tsconfig-paths": "^3.14.1"
       },
       "dependencies": {
@@ -4263,7 +4263,7 @@
         "is-core-module": "^2.11.0",
         "minimatch": "^3.1.2",
         "resolve": "^1.22.1",
-        "semver": "^7.3.8"
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "semver": {
@@ -4300,7 +4300,7 @@
         "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.4",
-        "semver": "^6.3.0",
+        "semver": "^7.5.4",
         "string.prototype.matchall": "^4.0.8"
       },
       "dependencies": {

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -96,7 +96,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.1",
-        "semver": "^6.3.0"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -168,7 +168,7 @@
         "@babel/compat-data": "^7.17.10",
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.20.2",
-        "semver": "^6.3.0"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -227,7 +227,7 @@
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
-        "semver": "^6.1.2"
+        "semver": "^7.5.4"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0-0"
@@ -1415,7 +1415,7 @@
         "babel-plugin-polyfill-corejs2": "^0.3.0",
         "babel-plugin-polyfill-corejs3": "^0.5.0",
         "babel-plugin-polyfill-regenerator": "^0.3.0",
-        "semver": "^6.3.0"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1611,7 +1611,7 @@
         "babel-plugin-polyfill-corejs3": "^0.5.0",
         "babel-plugin-polyfill-regenerator": "^0.3.0",
         "core-js-compat": "^3.22.1",
-        "semver": "^6.3.0"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2260,7 +2260,7 @@
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.7",
+        "semver": "^7.5.4",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -2389,7 +2389,7 @@
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
+        "semver": "^7.5.4",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -2537,7 +2537,7 @@
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "core-js": "^3.8.3",
         "core-js-compat": "^3.8.3",
-        "semver": "^7.3.4"
+        "semver": "^7.5.4"
       },
       "peerDependencies": {
         "@babel/core": "*",
@@ -2902,7 +2902,7 @@
         "open": "^8.0.2",
         "ora": "^5.3.0",
         "read-pkg": "^5.1.1",
-        "semver": "^7.3.4",
+        "semver": "^7.5.4",
         "strip-ansi": "^6.0.0"
       }
     },
@@ -3728,7 +3728,7 @@
       "dependencies": {
         "@babel/compat-data": "^7.13.11",
         "@babel/helper-define-polyfill-provider": "^0.3.1",
-        "semver": "^6.1.1"
+        "semver": "^7.5.4"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -4564,7 +4564,7 @@
       "dev": true,
       "dependencies": {
         "browserslist": "^4.20.3",
-        "semver": "7.0.0"
+        "semver": "7.5.4"
       },
       "funding": {
         "type": "opencollective",
@@ -4610,7 +4610,7 @@
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
-        "semver": "^5.5.0",
+        "semver": "^7.5.4",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       },
@@ -4652,7 +4652,7 @@
         "postcss-modules-scope": "^3.0.0",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^7.3.5"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">= 12.13.0"
@@ -5468,7 +5468,7 @@
         "optionator": "^0.9.1",
         "progress": "^2.0.0",
         "regexpp": "^3.1.0",
-        "semver": "^7.2.1",
+        "semver": "^7.5.4",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
         "table": "^6.0.9",
@@ -5495,7 +5495,7 @@
         "natural-compare": "^1.4.0",
         "nth-check": "^2.0.1",
         "postcss-selector-parser": "^6.0.9",
-        "semver": "^7.3.5",
+        "semver": "^7.5.4",
         "vue-eslint-parser": "^8.0.1"
       },
       "engines": {
@@ -6325,7 +6325,7 @@
         "memfs": "^3.1.2",
         "minimatch": "^3.0.4",
         "schema-utils": "2.7.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.4",
         "tapable": "^1.0.0"
       },
       "engines": {
@@ -7804,7 +7804,7 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "dependencies": {
-        "semver": "^6.0.0"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=8"
@@ -8851,7 +8851,7 @@
       "dependencies": {
         "cosmiconfig": "^7.0.0",
         "klona": "^2.0.5",
-        "semver": "^7.3.5"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">= 12.13.0"
@@ -10698,7 +10698,7 @@
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.0.0",
         "micromatch": "^4.0.0",
-        "semver": "^7.3.4"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -11013,7 +11013,7 @@
         "espree": "^9.0.0",
         "esquery": "^1.4.0",
         "lodash": "^4.17.21",
-        "semver": "^7.3.5"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -12021,7 +12021,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.1",
-        "semver": "^6.3.0"
+        "semver": "^7.5.4"
       }
     },
     "@babel/generator": {
@@ -12076,7 +12076,7 @@
         "@babel/compat-data": "^7.17.10",
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.20.2",
-        "semver": "^6.3.0"
+        "semver": "^7.5.4"
       }
     },
     "@babel/helper-create-class-features-plugin": {
@@ -12117,7 +12117,7 @@
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
-        "semver": "^6.1.2"
+        "semver": "^7.5.4"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -12912,7 +12912,7 @@
         "babel-plugin-polyfill-corejs2": "^0.3.0",
         "babel-plugin-polyfill-corejs3": "^0.5.0",
         "babel-plugin-polyfill-regenerator": "^0.3.0",
-        "semver": "^6.3.0"
+        "semver": "^7.5.4"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -13060,7 +13060,7 @@
         "babel-plugin-polyfill-corejs3": "^0.5.0",
         "babel-plugin-polyfill-regenerator": "^0.3.0",
         "core-js-compat": "^3.22.1",
-        "semver": "^6.3.0"
+        "semver": "^7.5.4"
       }
     },
     "@babel/preset-modules": {
@@ -13618,7 +13618,7 @@
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.7",
+        "semver": "^7.5.4",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
@@ -13683,7 +13683,7 @@
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
+        "semver": "^7.5.4",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
@@ -13794,7 +13794,7 @@
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "core-js": "^3.8.3",
         "core-js-compat": "^3.8.3",
-        "semver": "^7.3.4"
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "semver": {
@@ -14053,7 +14053,7 @@
         "open": "^8.0.2",
         "ora": "^5.3.0",
         "read-pkg": "^5.1.1",
-        "semver": "^7.3.4",
+        "semver": "^7.5.4",
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
@@ -14730,7 +14730,7 @@
       "requires": {
         "@babel/compat-data": "^7.13.11",
         "@babel/helper-define-polyfill-provider": "^0.3.1",
-        "semver": "^6.1.1"
+        "semver": "^7.5.4"
       }
     },
     "babel-plugin-polyfill-corejs3": {
@@ -15346,7 +15346,7 @@
       "dev": true,
       "requires": {
         "browserslist": "^4.20.3",
-        "semver": "7.0.0"
+        "semver": "7.5.4"
       },
       "dependencies": {
         "semver": {
@@ -15384,7 +15384,7 @@
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
-        "semver": "^5.5.0",
+        "semver": "^7.5.4",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       },
@@ -15417,7 +15417,7 @@
         "postcss-modules-scope": "^3.0.0",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^7.3.5"
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "semver": {
@@ -16016,7 +16016,7 @@
         "optionator": "^0.9.1",
         "progress": "^2.0.0",
         "regexpp": "^3.1.0",
-        "semver": "^7.2.1",
+        "semver": "^7.5.4",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
         "table": "^6.0.9",
@@ -16203,7 +16203,7 @@
         "natural-compare": "^1.4.0",
         "nth-check": "^2.0.1",
         "postcss-selector-parser": "^6.0.9",
-        "semver": "^7.3.5",
+        "semver": "^7.5.4",
         "vue-eslint-parser": "^8.0.1"
       },
       "dependencies": {
@@ -16644,7 +16644,7 @@
         "memfs": "^3.1.2",
         "minimatch": "^3.0.4",
         "schema-utils": "2.7.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.4",
         "tapable": "^1.0.0"
       },
       "dependencies": {
@@ -17740,7 +17740,7 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "requires": {
-        "semver": "^6.0.0"
+        "semver": "^7.5.4"
       }
     },
     "mdn-data": {
@@ -18510,7 +18510,7 @@
       "requires": {
         "cosmiconfig": "^7.0.0",
         "klona": "^2.0.5",
-        "semver": "^7.3.5"
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -19862,7 +19862,7 @@
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.0.0",
         "micromatch": "^4.0.0",
-        "semver": "^7.3.4"
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -20098,7 +20098,7 @@
         "espree": "^9.0.0",
         "esquery": "^1.4.0",
         "lodash": "^4.17.21",
-        "semver": "^7.3.5"
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "eslint-scope": {


### PR DESCRIPTION
Closes Dependabot alert #16 which is titled as "semver vulnerable to Regular Expression Denial of Service".

Fixes CVE-2022-25883 security vulnerability.

Description: Versions of the package semver before 7.5.2 on the 7.x branch, before 6.3.1 on the 6.x branch, and all other versions before 5.7.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.

Package: semver (npm)
Affected versions: >= 7.0.0, < 7.5.2
Patched version: 7.5.2
Bumped version: 7.5.4

Severity: Moderate (ranked 5.3 from 10)
CVSS base metrics standard: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L
Attack vector: Network
Attack complexity: Low
Privileges required: None
User interaction: None
Scope: Unchanged
Confidentiality: None
Integrity: None
Availability: Low
Tags: Development dependency; Patch available
Weaknesses: CWE-1333
CVE ID: CVE-2022-25883
GHSA ID: GHSA-c2qf-rxjj-qqgw